### PR TITLE
Fix issues in README generation and branches' comparison

### DIFF
--- a/AiGitCraft.Rproj
+++ b/AiGitCraft.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace,vignette

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: AiGitCraft
 Type: Package
 Title: AiGitCraft: AI-enhanced Git Operations
 Description: AiGitCraft is an R package designed to enhance Git operations by leveraging Large Language Models (LLMs) to automatically generate meaningful commit messages, pull request descriptions, and other related documentation.
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Angelo", "D'Ambrosio", , "a.dambrosioMD@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2045-5155"))

--- a/R/LLM_calls.R
+++ b/R/LLM_calls.R
@@ -182,7 +182,8 @@ prompt_llm <- function(
   llm_fun <- paste0("use_", provider, "_llm")
 
   if (!exists(llm_fun, mode = "function")) {
-    stop("Unsupported LLM provider.")
+    stop("Unsupported LLM provider.
+         You can set it project-wide using the aigitcraft_default_llm_provider option.")
   }
 
   llm_fun <- get(llm_fun)

--- a/R/LLM_operations.R
+++ b/R/LLM_operations.R
@@ -287,19 +287,23 @@ write_repo_readme <- function(
     use_description = TRUE,
     use_current_readme = TRUE,
     file_exts = getOption("aigitcraft_file_exts"),
-    screened_folders = getOption("aigitcraft_screened_folders", repo),
+    screened_folders = getOption("aigitcraft_screened_folders", repo_path),
     recursive = TRUE,
     ...
 ) {
 
-  withr::with_dir(repo, {
+  withr::with_dir(repo_path, {
 
     system_prompt = "You are an AI expert in git and version control understanding, whose goal is to help a developer write a README file for a code repository."
 
     # Get the content of the code files
     file_text <- list.files(
       screened_folders, full.names = T, recursive = T,
-      pattern = paste0(".", file_exts |> paste(collapse = "|"), "$"),
+      pattern = if (!is.null(file_exts)) {
+        paste0("\\.(", file_exts |> paste(collapse = "|"), ")$")
+        } else {
+          "\\.[^\\.]+$"
+        },
       ignore.case = T) |>
       stringr::str_subset("README", negate = T) |>
       purrr::map_chr(~ paste0(

--- a/R/git_operations.R
+++ b/R/git_operations.R
@@ -87,6 +87,12 @@ get_commit_differences <- function(
 
   no_comparison <- FALSE
 
+  # If there are no screened folders, set screened_folders to NULL
+  # otherwise, git2r::diff will throw an error
+  if (length(screened_folders) == 0) {
+    screened_folders <- NULL
+  }
+
   # The use of the parent commit is done here instead of as default argument to
   # have a marker that we are describing the target commit only
   if (is.null(source_commit)) {


### PR DESCRIPTION
- **FIx README Generation Logic** (Commit: f633f7ac)
The pattern matching for file extensions within the `write_repo_readme` function has been streamlined for better clarity and maintainability. The updated logic now uses conditional construction of the regex pattern to ensure that only specified file extensions are included in the README generation process when provided. This change simplifies the inclusion logic and makes the function more robust when dealing with different file types.

- **Fix an issue with branch comparison when no screened_folder set is used** (Commit: f158ded)
`write_pull_request_description()` failed if no value was passed to `screened_folders`.

- **Enhanced Error Messaging for LLM Providers** (Commit: 8f993286)
An improved error message has been implemented to guide users when an unsupported LLM provider is set. This enhancement makes the configuration requirements clearer and aids in troubleshooting, thereby improving the overall user experience. The error message now suggests setting the provider project-wide using the `aigitcraft_default_llm_provider` option, a helpful pointer for users configuring their environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messaging for unsupported LLM providers with helpful suggestions.
	- Improved flexibility in file extension matching for repository operations.
- **Enhancements**
	- Updated project configuration to support Roxygen documentation generation.
	- Improved internal handling of directory operations and git differences.
- **Documentation**
	- Updated the package version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->