### PR TITLE
hotfix: ensure proper diff retrieval and error handling

### DIFF
--- a/R/git_operations.R
+++ b/R/git_operations.R
@@ -50,9 +50,11 @@ get_branch_differences <- function(
 
       # Append commit information and diff to output text
       tryCatch({
-        get_commit_differences(
+        res <- get_commit_differences(
           commit,
-          screened_folders = file.path(getwd(), screened_folders))
+          screened_folders = screened_folders)
+
+        if (is.null(res)) "" else res
       }, error = function(e) {
         warning(e)
         return("")
@@ -108,7 +110,8 @@ get_commit_differences <- function(
   # Get the diff between the commit and its parent
   # This may need adjustment for merge commits or more complex scenarios
   diff_data <- git2r::diff(
-    git2r::tree(target_commit), git2r::tree(source_commit),
+    x = git2r::tree(source_commit),
+    new_tree = git2r::tree(target_commit),
     as_char = TRUE, path = screened_folders)
 
   # If there are no differences, return NULL


### PR DESCRIPTION
- Commit comparison was being done in the wrong direction.
- Modify the get_branch_differences function to correctly capture and return the result of get_commit_differences, handling cases where the result is NULL.
- Adjust the get_commit_differences function to correctly specify the source and target trees when calling git2r::diff, ensuring accurate diff data is obtained.
- Improve error handling in get_branch_differences to provide a warning and return an empty string in case of an exception.